### PR TITLE
Remove the Docker-in-Docker configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,13 +9,7 @@
     "image": "mcr.microsoft.com/devcontainers/python:3.11-bullseye",
     // Features to add to the dev container. More info: https://containers.dev/features.
     "features": {
-        "ghcr.io/devcontainers/features/docker-in-docker:2": {
-            "moby": true,
-            "azureDnsAutoDetection": true,
-            "installDockerBuildx": true,
-            "version": "latest",
-            "dockerDashComposeVersion": "v2"
-        }
+        "ghcr.io/devcontainers/features/docker-in-docker:2": {}
     },
     // Use 'forwardPorts' to make a list of ports inside the container available locally.
     // "forwardPorts": [],


### PR DESCRIPTION
We dropped this for the research-template.

See opensafely/research-template#129.