### PR TITLE
Add rudimentary scheduled check of dev container

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,12 +17,12 @@ jobs:
         with:
           runCmd: opensafely run run_all
 
-      # - name: Notify Slack on failure
-      #   if: failure() && github.event_name == 'schedule'
-      #   uses: zuplo/github-action-slack-notify-build@cf8e7e66a21d76a8125ea9648979c30920195552 # v2
-      #   env:
-      #     SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-      #   with:
-      #     channel_id: <TODO: add a channel id>
-      #     status: "Scheduled dev container test run failure"
-      #     color: danger
+      - name: Notify Slack on failure
+        if: failure() && github.event_name == 'schedule'
+        uses: zuplo/github-action-slack-notify-build@cf8e7e66a21d76a8125ea9648979c30920195552 # v2
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        with:
+          channel_id: C069YDR4NCA
+          status: "Scheduled dev container test run failure"
+          color: danger

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,28 @@
+name: Test dev container
+
+on:
+  schedule:
+    - cron: "56 5 * * *"
+  workflow_dispatch:
+
+jobs:
+  dev-container:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Test dev container
+        uses: devcontainers/ci@a56d055efecd725e8cfe370543b6071b79989cc8 # v0.3.1900000349
+        with:
+          runCmd: opensafely run run_all
+
+      # - name: Notify Slack on failure
+      #   if: failure() && github.event_name == 'schedule'
+      #   uses: zuplo/github-action-slack-notify-build@cf8e7e66a21d76a8125ea9648979c30920195552 # v2
+      #   env:
+      #     SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      #   with:
+      #     channel_id: <TODO: add a channel id>
+      #     status: "Scheduled dev container test run failure"
+      #     color: danger

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Test dev container
-        uses: devcontainers/ci@a56d055efecd725e8cfe370543b6071b79989cc8 # v0.3.1900000349
+        uses: devcontainers/ci@8bf61b26e9c3a98f69cb6ce2f88d24ff59b785c6 # v0.3.1900000417
         with:
           runCmd: opensafely run run_all
 


### PR DESCRIPTION
Fixes #9.

#6 was reported by a user. It would be preferable to catch such breakage ourselves; running a scheduled check could help there.