### PR TITLE
Add OpenSAFELY VSCode extension to config

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,7 +21,8 @@
             "extensions": [
                 "ms-python.python",
                 "ms-toolsai.jupyter",
-                "ms-toolsai.jupyter-renderers"
+                "ms-toolsai.jupyter-renderers",
+                "bennettoxford.opensafely"
             ]
         }
     },


### PR DESCRIPTION
This install our custom VSCode extension:
https://marketplace.visualstudio.com/items?itemName=bennettoxford.opensafely

I've tested this by opening a Codespace from the branch page:
https://github.com/opensafely/ehrql-tutorial/tree/evansd/opensafely-vscode-extension

And confirmed that our extension is installed and behaves as expected.