### PR TITLE
Move settings back to .vscode/settings.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -27,20 +27,6 @@
                 "bennettoxford.opensafely"
             ]
         },
-        "settings": {
-            "files.associations": {
-                "*.feather": "arrow"
-            },
-            "files.autoSave": "afterDelay",
-            "files.autoSaveDelay": 1000,
-            "window.autoDetectColorScheme": true,
-            "extensions.ignoreRecommendations": true,
-            "workbench.colorTheme":"Visual Studio Light",
-            "editor.minimap.enabled": false,
-            "editor.wordWrap": "on",
-            "terminal.integrated.hideOnStartup": "always",
-            "terminal.integrated.enableFileLinks": "on"
-        }
     },
     // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
     // "remoteUser": "root"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,14 @@
+{
+    "files.associations": {
+        "*.feather": "arrow"
+    },
+    "files.autoSave": "afterDelay",
+    "files.autoSaveDelay": 1000,
+    "window.autoDetectColorScheme": true,
+    "extensions.ignoreRecommendations": true,
+    "workbench.colorTheme":"Visual Studio Light",
+    "editor.minimap.enabled": false,
+    "editor.wordWrap": "on",
+    "terminal.integrated.hideOnStartup": "always",
+    "terminal.integrated.enableFileLinks": "on"
+}


### PR DESCRIPTION
They're not being applied in a codespace from devcontainer.json. This looks like it might be another difference between standard devcontainers and codespaces.