### PR TITLE
Slightly better quiz hint to avoid confusion

### DIFF
--- a/quiz.py
+++ b/quiz.py
@@ -95,6 +95,6 @@ questions[9].check(...)
 # Create a boolean patient series identifying patients without moderate or severe frailty in whom
 # the last IFCC-HbA1c is 58 mmol/mol or less
 questions[10].check(...)
-# questions[10.hint()
+# questions[10].hint()
 
 questions.summarise()

--- a/quiz_answers.py
+++ b/quiz_answers.py
@@ -92,12 +92,12 @@ questions.set_dummy_tables_path("dummy_tables")
 
 remember_brackets = (
     "\n\nRemember your brackets. Things like this:\n\n"
-    "  has_diabetes & latest_hba1c < 50\n\n"
+    "  has_diagnosis & latest_value < 58\n\n"
     "won't work because the '&' gets evaluated first, so it's as if you'd written:\n\n"
-    "  (has_diabetes & latest_hba1c) < 50\n\n"
+    "  (has_diagnosis & latest_value) < 58\n\n"
     "which doesn't make sense and will lead to an error. Instead you need to add brackets "
     "to make the order of the operations explicit:\n\n"
-    "  has_diabetes & (latest_hba1c < 50)"
+    "  has_diagnosis & (latest_value < 58)"
 )
 
 


### PR DESCRIPTION
A user commented that the hint was confusing for q10. It was because the generic "remember brackets" message gave `has_diabetes` and `latest_hba1c < 50` as examples. This was confusing because q10 needs hba1c <= 58 and doesn't require diabetes. This changes the variable names to more generic ones, but also changes the 50 to 58.