### PR TITLE
Update to Python 3.13

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/devcontainers/python:3.11-bullseye
+FROM mcr.microsoft.com/devcontainers/python:3.13-bullseye
 
 # Suppress the codespace's default first run message
 # See https://github.com/devcontainers/features/blob/main/src/common-utils/scripts/rc_snippet.sh


### PR DESCRIPTION
Fixes #26.

ehrQL was updated to Python 3.13, but the configuration here was not updated. The dev container build was therefore failing as the latest ehrQL version (which was build uses) was incompatible with the Python in the Docker image.