### PR TITLE
Fix build failures by updating Debian base image

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/devcontainers/python:3.13-bullseye
+FROM mcr.microsoft.com/devcontainers/python:3.13-trixie
 
 # Suppress the codespace's default first run message
 # See https://github.com/devcontainers/features/blob/main/src/common-utils/scripts/rc_snippet.sh

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,7 +11,11 @@
     },
     // Features to add to the dev container. More info: https://containers.dev/features.
     "features": {
-        "ghcr.io/devcontainers/features/docker-in-docker:2": {}
+        "ghcr.io/devcontainers/features/docker-in-docker:2": {
+            // This is incompatible with the Debian Trixie image we are using
+            // See: https://github.com/opensafely/ehrql-tutorial/pull/31
+            "moby": false
+        }
     },
     // Use 'forwardPorts' to make a list of ports inside the container available locally.
     // "forwardPorts": [],

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,6 @@ jobs:
         env:
           SLACK_BOT_TOKEN: ${{ secrets.BENNETTBOT_SLACK_BOT_TOKEN }}
         with:
-          channel_id: C069YDR4NCA
+          channel_id: C0A8WAJMK0S
           status: "Scheduled dev container test run failure"
           color: danger


### PR DESCRIPTION
These were detected by the scheduled build action which triggers alerts to `#team-rap`.

Yarn have [recently invalidated](https://github.com/yarnpkg/yarn/issues/9216) their old apt key leading to errors when attempting to build the `docker-in-docker` feature:

        0.519 The following signatures were invalid: EXPKEYSIG
          23E7166788B63E1E Yarn Packaging <yarn@dan.cx>
        1.547 W: GPG error: https://dl.yarnpkg.com/debian stable
          InRelease: The following signatures were invalid: EXPKEYSIG
          23E7166788B63E1E Yarn Packaging <yarn@dan.cx>
        1.547 E: The repository 'https://dl.yarnpkg.com/debian stable
          InRelease' is not signed.
        1.549 ERROR: Feature "Docker (Docker-in-Docker)"
          (ghcr.io/devcontainers/features/docker-in-docker) failed to
          install! Look at the documentation at
          https://github.com/devcontainers/features/tree/main/src/docker-in-docker
          for help troubleshooting this error.

It would have been possible just to pull in the new key, but updating the base image seems like a more future-proof solution.

This does involve switching from `moby` to `docker-ce` (as per [this issue](https://github.com/devcontainers/features/issues/1466)) but apparently we were [considering](https://github.com/opensafely/research-template/pull/129#issuecomment-2136838889) doing that anyway.

We also update the alerts to go to the new `#team-rap-alerts` channel.

I've confirmed that I can open a new Codepsace from this branch and run the quiz successfully.